### PR TITLE
Refactor: reorganización de espacios de nombres

### DIFF
--- a/Data/Repositories/EmpresaRepository.cs
+++ b/Data/Repositories/EmpresaRepository.cs
@@ -1,4 +1,4 @@
-﻿using PruebaTecnica.Interfaces;
+﻿using PruebaTecnica.Data.Repositories.Impl;
 using PruebaTecnica.Models;
 using System;
 using System.Collections.Generic;

--- a/Data/Repositories/Impl/IEmpresaRepository.cs
+++ b/Data/Repositories/Impl/IEmpresaRepository.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace PruebaTecnica.Interfaces
+namespace PruebaTecnica.Data.Repositories.Impl
 {
     public interface IEmpresaRepository
     {

--- a/Forms/FormCompanyEditor.cs
+++ b/Forms/FormCompanyEditor.cs
@@ -1,7 +1,6 @@
 ﻿using PruebaTecnica.Data;
-using PruebaTecnica.Interfaces;
 using PruebaTecnica.Models;
-using PruebaTecnica.Services;
+using PruebaTecnica.Services.Impl;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Forms/FormCompanyList.cs
+++ b/Forms/FormCompanyList.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using PruebaTecnica.Interfaces;
 using PruebaTecnica.Models;
-using PruebaTecnica.Services;
+using PruebaTecnica.Services.Impl;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Program.cs
+++ b/Program.cs
@@ -5,7 +5,8 @@ using Microsoft.EntityFrameworkCore;
 using PruebaTecnica.Forms;
 using PruebaTecnica.Data.Repositories;
 using PruebaTecnica.Services;
-using PruebaTecnica.Interfaces;
+using PruebaTecnica.Data.Repositories.Impl;
+using PruebaTecnica.Services.Impl;
 
 
 namespace PruebaTecnica

--- a/Services/EmpresaService.cs
+++ b/Services/EmpresaService.cs
@@ -1,6 +1,7 @@
 ﻿using PruebaTecnica.Data.Repositories;
-using PruebaTecnica.Interfaces;
+using PruebaTecnica.Data.Repositories.Impl;
 using PruebaTecnica.Models;
+using PruebaTecnica.Services.Impl;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Services/Impl/IEmpresaService.cs
+++ b/Services/Impl/IEmpresaService.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace PruebaTecnica.Interfaces
+namespace PruebaTecnica.Services.Impl
 {
     public interface IEmpresaService
     {


### PR DESCRIPTION
Se reorganizaron las rutas de los espacios de nombres para las interfaces `IEmpresaRepository` e `IEmpresaService`, moviéndolas a `PruebaTecnica.Data.Repositories.Impl` y
`PruebaTecnica.Services.Impl`, respectivamente.

Se actualizaron las referencias en los archivos afectados:
- `EmpresaRepository.cs`, `EmpresaService.cs`, `FormCompanyEditor.cs`, `FormCompanyList.cs` y `Program.cs`.

Se eliminaron las definiciones previas de las interfaces en `PruebaTecnica.Interfaces` y se añadieron nuevas definiciones en los espacios de nombres correspondientes.